### PR TITLE
Fix: Configure Express server to serve the SPA

### DIFF
--- a/wealthlog/apps/backend/src/index.js
+++ b/wealthlog/apps/backend/src/index.js
@@ -141,6 +141,26 @@ app.use('/generalSettings', generalSettingsRouter);
 app.use('/tradingSettings', tradingSettingsRouter);
 app.use("/trade/insights", tradingInsightsRouter);
 
+// =================================================================
+//  SERVE FRONTEND APPLICATION
+// =================================================================
+
+// Define the path to the frontend's build output directory.
+// This path is relative to the location of this index.js file.
+const frontendPath = path.join(__dirname, '..', '..', 'web', 'out');
+
+// Serve the static files (JS, CSS, images) from the frontend build directory
+// The '/en' path is important to match the frontend's basePath
+app.use('/en', express.static(frontendPath));
+
+// For any other request that isn't an API call or a static file,
+// send the main index.html file. This enables SPA routing.
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve(frontendPath, 'index.html'));
+});
+
+// =================================================================
+
 // Start the server
 app.listen(PORT, () => {
   logger.info(`🚀 WealthLog API running on port ${PORT}`);

--- a/wealthlog/apps/web/next.config.js
+++ b/wealthlog/apps/web/next.config.js
@@ -2,6 +2,8 @@ const path = require('path');
 const withNextIntl = require('next-intl/plugin')();
 
 const nextConfig = {
+  basePath: '/en',
+  output: 'export',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
This commit configures the Express.js backend to correctly serve the Next.js frontend application, resolving a 404 error for frontend routes.

The changes include:
1.  **Backend (index.js):**
    - Added middleware to serve static files from the frontend's build directory (`wealthlog/apps/web/out`).
    - Added a catch-all route (`app.get('*', ...)`) to serve `index.html` for all non-API requests, enabling client-side routing for the SPA.

2.  **Frontend (next.config.js):**
    - Set `basePath: '/en'` to ensure all application routes and asset paths are correctly prefixed.
    - Set `output: 'export'` to enable static site generation, producing the necessary static files for the backend to serve.